### PR TITLE
Updated opentelemetry version restriction which was causing protobuf …

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -43,7 +43,7 @@ watchfiles # required for http server to monitor the updates of TLS files
 python-json-logger # Used by logging as per examples/other/logging_configuration.md
 scipy # Required for phi-4-multimodal-instruct
 ninja # Required for xgrammar, rocm, tpu, xpu
-opentelemetry-sdk>=1.26.0,<1.27.0  # vllm.tracing
-opentelemetry-api>=1.26.0,<1.27.0  # vllm.tracing
-opentelemetry-exporter-otlp>=1.26.0,<1.27.0  # vllm.tracing
-opentelemetry-semantic-conventions-ai>=0.4.1,<0.5.0  # vllm.tracing
+opentelemetry-sdk>=1.26.0  # vllm.tracing
+opentelemetry-api>=1.26.0  # vllm.tracing
+opentelemetry-exporter-otlp>=1.26.0  # vllm.tracing
+opentelemetry-semantic-conventions-ai>=0.4.1  # vllm.tracing


### PR DESCRIPTION
There is a conflict while installing all the packages in the final stage due to following 
```
vllm depends on opentelemetry-exporter-otlp>=1.26.0,<1.27.0
opentelemetry-exporter-otlp==1.26.0 depends on **protobuf>=3.19,<5.0**
vllm-tgis-adapter==0.7.1 depends on grpcio-health-checking==1.70.0
grpcio-health-checking==1.70.0 depends on **protobuf>=5.26.1,<6.0.dev0**
```

Removing upper version restriction from opentelemetry fixes the conflict as opentelemetry==1.34 depends on higher protobuf.

Again this is an attempt to fix the issue, not sure if this will resolve Konflux build errors.

FYI @riprasad 