### PR TITLE
Fixed undefined symbol errors when vllm is built on Power9

### DIFF
--- a/cmake/cpu_extension.cmake
+++ b/cmake/cpu_extension.cmake
@@ -175,7 +175,7 @@ if (AVX512_FOUND AND NOT AVX512_DISABLED)
     FetchContent_MakeAvailable(oneDNN)
     
     list(APPEND LIBS dnnl)
-elseif(POWER10_FOUND)
+elseif(POWER10_FOUND OR POWER9_FOUND)
     FetchContent_Declare(
         oneDNN
         GIT_REPOSITORY https://github.com/oneapi-src/oneDNN.git
@@ -231,7 +231,7 @@ if (AVX512_FOUND AND NOT AVX512_DISABLED)
         "csrc/cpu/quant.cpp"
         "csrc/cpu/shm.cpp"
         ${VLLM_EXT_SRC})
-elseif(POWER10_FOUND)
+elseif(POWER10_FOUND OR POWER9_FOUND)
     set(VLLM_EXT_SRC
         "csrc/cpu/quant.cpp"
         ${VLLM_EXT_SRC})


### PR DESCRIPTION
When vllm was built on Power9, at runtime we used to get undefined symbol error as below -
```
WARNING 06-26 06:46:54 [importing.py:29] Triton is not installed. Using dummy decorators. Install it via `pip install triton` to enable kernel compilation.
INFO 06-26 06:46:59 [__init__.py:244] Automatically detected platform cpu.
WARNING 06-26 06:47:01 [_custom_ops.py:22] Failed to import from vllm._C with ImportError('/opt/vllm/lib64/python3.12/site-packages/vllm/_C.abi3.so: undefined symbol: _Z24static_scaled_int8_quantRN2at6TensorERKS0_S3_RKSt8optionalIS0_E')
```
Although this was just a warning, but it makes import of `vllm._C` fails due to which other symbols like torch.ops.silu_and_mul or "init_cpu_threads" as undefined. 
```
AttributeError: '_OpNamespace' '_C' object has no attribute 'silu_and_mul'
```
This PR addresses those issues.
Even after this is resolved, at runtime, we need to set ` VLLM_CPU_OMP_THREADS_BIND="all"` so that vllm works with NUMA.