### PR TITLE
Fixed undefined symbol errors when vllm is built on Power9

### DIFF
--- a/cmake/cpu_extension.cmake
+++ b/cmake/cpu_extension.cmake
@@ -192,7 +192,7 @@ if (AVX512_FOUND AND NOT AVX512_DISABLED)
     FetchContent_MakeAvailable(oneDNN)
     
     list(APPEND LIBS dnnl)
-elseif(POWER10_FOUND)
+elseif(POWER10_FOUND OR POWER9_FOUND)
     FetchContent_Declare(
         oneDNN
         GIT_REPOSITORY https://github.com/oneapi-src/oneDNN.git
@@ -259,7 +259,7 @@ if (AVX512_FOUND AND NOT AVX512_DISABLED)
             ${VLLM_EXT_SRC})
         add_compile_definitions(-DCPU_CAPABILITY_AVX512)
     endif()
-elseif(POWER10_FOUND)
+elseif(POWER10_FOUND OR POWER9_FOUND)
     set(VLLM_EXT_SRC
         "csrc/cpu/quant.cpp"
         ${VLLM_EXT_SRC})


### PR DESCRIPTION
Backported the fix from rhoai-2.22 https://github.com/red-hat-data-services/vllm-cpu/pull/50/files