### PR TITLE
Fixed vllm build issues on power

### DIFF
--- a/Dockerfile.ppc64le.ubi
+++ b/Dockerfile.ppc64le.ubi
@@ -1,4 +1,4 @@
-ARG BASE_UBI_IMAGE_TAG=9.5-1742914212
+ARG BASE_UBI_IMAGE_TAG=9.6-1754584681
 ARG VLLM_VERSION
 ARG VLLM_TGIS_ADAPTER_VERSION=0.7.1
 
@@ -9,7 +9,7 @@ ARG VLLM_TGIS_ADAPTER_VERSION=0.7.1
 FROM registry.access.redhat.com/ubi9/ubi-minimal:${BASE_UBI_IMAGE_TAG} AS openblas-builder
 
 ARG MAX_JOBS
-ARG OPENBLAS_VERSION=0.3.29
+ARG OPENBLAS_VERSION=0.3.30
 RUN microdnf install -y dnf && dnf install -y gcc-toolset-13 make wget unzip \
     && source /opt/rh/gcc-toolset-13/enable \
     && wget https://github.com/OpenMathLib/OpenBLAS/releases/download/v$OPENBLAS_VERSION/OpenBLAS-$OPENBLAS_VERSION.zip \
@@ -39,7 +39,7 @@ RUN dnf install -y openjpeg2-devel lcms2-devel tcl-devel tk-devel fribidi-devel 
 FROM centos-deps-builder AS base-builder
 
 ARG PYTHON_VERSION=3.12
-ARG OPENBLAS_VERSION=0.3.29
+ARG OPENBLAS_VERSION=0.3.30
 
 # Set Environment Variables for venv, cargo & openblas
 ENV VIRTUAL_ENV=/opt/vllm
@@ -286,8 +286,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     source /opt/rh/gcc-toolset-13/enable && export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 && \
     uv pip install pythran pybind11 /opencvwheels/*.whl /arrowwheels/*.whl /torchwheels/*.whl /numbawheels/*.whl && \
     sed -i -e 's/.*torch.*//g' /src/pyproject.toml /src/requirements/*.txt && \
-    uv pip install pandas /hf_wheels/*.whl && \
+    sed -i -e 's/.*sentencepiece.*//g' /src/pyproject.toml /src/requirements/*.txt && \
+    uv pip install sentencepiece==0.2.0 pandas /hf_wheels/*.whl && \
     make -C /numactl install && \
+    sed -i -e 's/^transformers.*/&, <4.54.0/g' /src/requirements/common.txt && \
     uv pip install -r /src/requirements/common.txt -r /src/requirements/cpu.txt -r /src/requirements/build.txt --no-build-isolation && \
     cd /src/ && \
     SETUPTOOLS_SCM_PRETEND_VERSION="$VLLM_VERSION" \
@@ -315,7 +317,7 @@ RUN git clone --recursive https://github.com/Reference-LAPACK/lapack.git -b v${L
 FROM registry.access.redhat.com/ubi9/ubi-minimal:${BASE_UBI_IMAGE_TAG} AS vllm-openai
 
 ARG PYTHON_VERSION=3.12
-ARG OPENBLAS_VERSION=0.3.29
+ARG OPENBLAS_VERSION=0.3.30
 ENV VLLM_NO_USAGE_STATS=1
 
 # Set Environment Variables for venv & openblas


### PR DESCRIPTION
Latest transformer and vllm <0.10 cause an issue as follows -

```
in <module>
    from vllm.transformers_utils.configs import (ChatGLMConfig, Cohere2Config,
  File "/opt/vllm/lib64/python3.12/site-packages/vllm/transformers_utils/configs/__init__.py", line 26, in <module>
    from vllm.transformers_utils.configs.ovis import OvisConfig
  File "/opt/vllm/lib64/python3.12/site-packages/vllm/transformers_utils/configs/ovis.py", line 76, in <module>
    AutoConfig.register("aimv2", AIMv2Config)
  File "/opt/vllm/lib64/python3.12/site-packages/transformers/models/auto/configuration_auto.py", line 1306, in register
    CONFIG_MAPPING.register(model_type, config, exist_ok=exist_ok)
  File "/opt/vllm/lib64/python3.12/site-packages/transformers/models/auto/configuration_auto.py", line 993, in register
    raise ValueError(f"'{key}' is already used by a Transformers config, pick another name.")
ValueError: 'aimv2' is already used by a Transformers config, pick another name.
```
For this, restricting transformer to <4.54 fixes this. 
The latest vllm code in the upstream has fixed this issue, so we would need to undo this change once downstream is sync'ed with upstream latest changes.

sentencepiece 0.2.1 also fails to compile from source on Power which is released just last week. Once that build issue is resolved, even sentencepiece can be unpinned.

## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS ABOVE HAVE BEEN CONSIDERED.

## Purpose

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
