### PR TITLE
Fixed sentencepiece installation in the final stage

### DIFF
--- a/Dockerfile.ppc64le.ubi
+++ b/Dockerfile.ppc64le.ubi
@@ -369,6 +369,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,from=vllmcache-builder,source=/hf_wheels/,target=/hf_wheels/,ro \
     --mount=type=bind,from=vllmcache-builder,source=/vllmwheel/,target=/vllmwheel/,ro \
     --mount=type=bind,from=numba-builder,source=/numbawheels/,target=/numbawheels/,ro \
+    export PKG_CONFIG_PATH=$(find / -type d -name "pkgconfig" 2>/dev/null | tr '\n' ':') && uv pip install sentencepiece==0.2.0 && \
     HOME=/root uv pip install /opencvwheels/*.whl /arrowwheels/*.whl /torchwheels/*.whl /hf_wheels/*.whl /numbawheels/*.whl /vllmwheel/*.whl
 
 WORKDIR /home/vllm


### PR DESCRIPTION
sentencepiece 0.2.1 doesn't build on Power with just `pip install sentencepiece`. So, in the previous stage we do build the SP 0.2.0 and have it cached. But vllm when installed in the final stage fails with following error. So, to fix that we need the fix in the PR.

```
 Building sentencepiece==0.2.1
 Downloading transformers
  × Failed to build `sentencepiece==0.2.1`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)

      [stdout]
      running bdist_wheel
      running build
      running build_py
      creating build
      creating build/lib.linux-ppc64le-cpython-312
      creating build/lib.linux-ppc64le-cpython-312/sentencepiece
      copying src/sentencepiece/__init__.py ->
      build/lib.linux-ppc64le-cpython-312/sentencepiece
      copying src/sentencepiece/_version.py ->
      build/lib.linux-ppc64le-cpython-312/sentencepiece
      copying src/sentencepiece/sentencepiece_model_pb2.py ->
      build/lib.linux-ppc64le-cpython-312/sentencepiece
      copying src/sentencepiece/sentencepiece_pb2.py ->
      build/lib.linux-ppc64le-cpython-312/sentencepiece
      copying src/sentencepiece/__init__.py ->
      build/lib.linux-ppc64le-cpython-312/sentencepiece/package_data
      copying src/sentencepiece/package_data/nmt_nfkc_cf.bin ->
      build/lib.linux-ppc64le-cpython-312/sentencepiece/package_data
      running build_ext
      -L/root/.cache/uv/sdists-v9/pypi/sentencepiece/0.2.0/dFQ4GzuRaUHkJkoNKD84C/src/build/root/lib64
      -lsentencepiece -lsentencepiece_train
       ....
      [stderr]
      ERROR setuptools_scm._file_finders.git listing git files failed -
      pretending there aren't any
      Package protobuf-lite was not found in the pkg-config search path.
      Perhaps you should add the directory containing `protobuf-lite.pc'
      to the PKG_CONFIG_PATH environment variable
      Package 'protobuf-lite', required by 'sentencepiece', not found
      Failed to find sentencepiece pkg-config

      hint: This usually indicates a problem with the package or the build
      environment.
Error: building at STEP "RUN --mount=type=cache,target=/root/.cache/uv --mount=type=bind,from=torch-builder,source=/torchwheels/,target=/torchwheels/,ro --mount=type=bind,from=arrow-builder,source=/arrowwheels/,target=/arrowwheels/,ro --mount=type=bind,from=cv-builder,source=/opencvwheels/,target=/opencvwheels/,ro --mount=type=bind,from=numa-builder,source=/numactl/,target=/numactl/,rw --mount=type=bind,from=numba-builder,source=/numbawheels/,target=/numbawheels/,ro --mount=type=bind,src=.,dst=/src/,rw source /opt/rh/gcc-toolset-13/enable &&     export PATH=$PATH:/usr/lib64/llvm15/bin &&     uv pip install /opencvwheels/*.whl /arrowwheels/*.whl /torchwheels/*.whl /numbawheels/*.whl &&     sed -i -e 's/.*torch.*//g' /src/pyproject.toml /src/requirements/*.txt &&     uv pip install pandas pythran nanobind pybind11 /hf_wheels/*.whl &&     make -C /numactl install &&     export PKG_CONFIG_PATH=$(find / -type d -name "pkgconfig" 2>/dev/null | tr '\n' ':') &&     nanobind_DIR=$(uv pip show nanobind | grep Location | sed 's/^Location: //;s/$/\/nanobind\/cmake/') && uv pip install -r /src/requirements/common.txt -r /src/requirements/cpu.txt -r /src/requirements/build.txt --no-build-isolation &&     cd /src/ &&     uv build --wheel --out-dir /vllmwheel/ --no-build-isolation &&     uv pip install /vllmwheel/*.whl": while running runtime: exit status 1
``` 


## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS ABOVE HAVE BEEN CONSIDERED.

## Purpose

## Test Plan

## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
