### PR TITLE
Fixed RHOAIENG 31377, 31376 and konflux build issues

### DIFF
--- a/Dockerfile.ppc64le.ubi
+++ b/Dockerfile.ppc64le.ubi
@@ -1,6 +1,8 @@
-ARG BASE_UBI_IMAGE_TAG=9.5-1742914212
+ARG BASE_UBI_IMAGE_TAG=9.6-1754584681
 ARG VLLM_VERSION
 ARG VLLM_TGIS_ADAPTER_VERSION=0.7.1
+ARG MAX_JOBS=8
+ARG PYARROW_PARALLEL=1
 
 ###############################################################
 # Stage to build openblas
@@ -15,7 +17,7 @@ RUN microdnf install -y dnf && dnf install -y gcc-toolset-13 make wget unzip \
     && wget https://github.com/OpenMathLib/OpenBLAS/releases/download/v$OPENBLAS_VERSION/OpenBLAS-$OPENBLAS_VERSION.zip \
     && unzip OpenBLAS-$OPENBLAS_VERSION.zip \
     && cd OpenBLAS-$OPENBLAS_VERSION \
-    &&  make -j${MAX_JOBS} TARGET=POWER9 BINARY=64 USE_OPENMP=1 USE_THREAD=1 NUM_THREADS=120 DYNAMIC_ARCH=1 INTERFACE64=0 \
+    &&  make -j ${MAX_JOBS:-$(nproc)} TARGET=POWER9 BINARY=64 USE_OPENMP=1 USE_THREAD=1 NUM_THREADS=120 DYNAMIC_ARCH=1 INTERFACE64=0 \
     && cd /tmp && touch control
 
 ###############################################################
@@ -55,7 +57,7 @@ ENV UV_LINK_MODE=copy
 
 COPY --from=openblas-builder /tmp/control /dev/null
 
-RUN --mount=type=bind,from=openblas-builder,source=/OpenBLAS-$OPENBLAS_VERSION/,target=/openblas/,rw \
+RUN --mount=type=cache,from=openblas-builder,source=/OpenBLAS-$OPENBLAS_VERSION/,target=/openblas/,rw \
     dnf install -y openssl-devel \
     && dnf install -y \
        git tar gcc-toolset-13 automake libtool \
@@ -269,6 +271,8 @@ ARG VLLM_TGIS_ADAPTER_VERSION
 ARG VLLM_TARGET_DEVICE=cpu
 ARG GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
 
+COPY ./ /src
+ 
 # this step installs vllm & tgis adapter and populates uv cache
 # with all the transitive dependencies
 RUN --mount=type=cache,target=/root/.cache/uv \
@@ -277,17 +281,18 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install maturin && \
     uv build --wheel --out-dir /hf_wheels/
 RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,from=torch-builder,source=/torchwheels/,target=/torchwheels/,ro \
-    --mount=type=bind,from=arrow-builder,source=/arrowwheels/,target=/arrowwheels/,ro \
-    --mount=type=bind,from=cv-builder,source=/opencvwheels/,target=/opencvwheels/,ro \
-    --mount=type=bind,from=numa-builder,source=/numactl/,target=/numactl/,ro \
-    --mount=type=bind,from=numba-builder,source=/numbawheels/,target=/numbawheels/,ro \
-    --mount=type=bind,src=.,dst=/src/,rw \
+    --mount=type=cache,from=torch-builder,source=/torchwheels/,target=/torchwheels/,ro \
+    --mount=type=cache,from=arrow-builder,source=/arrowwheels/,target=/arrowwheels/,ro \
+    --mount=type=cache,from=cv-builder,source=/opencvwheels/,target=/opencvwheels/,ro \
+    --mount=type=cache,from=numa-builder,source=/numactl/,target=/numactl/,ro \
+    --mount=type=cache,from=numba-builder,source=/numbawheels/,target=/numbawheels/,ro \
     source /opt/rh/gcc-toolset-13/enable && export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 && \
     uv pip install pythran pybind11 /opencvwheels/*.whl /arrowwheels/*.whl /torchwheels/*.whl /numbawheels/*.whl && \
     sed -i -e 's/.*torch.*//g' /src/pyproject.toml /src/requirements/*.txt && \
-    uv pip install pandas /hf_wheels/*.whl && \
+    sed -i -e 's/.*sentencepiece.*//g' /src/pyproject.toml /src/requirements/*.txt && \
+    uv pip install sentencepiece==0.2.0 pandas /hf_wheels/*.whl && \
     make -C /numactl install && \
+    sed -i -e 's/^transformers.*/&, <4.54.0/g' /src/requirements/common.txt && \
     uv pip install -r /src/requirements/common.txt -r /src/requirements/cpu.txt -r /src/requirements/build.txt --no-build-isolation && \
     cd /src/ && \
     SETUPTOOLS_SCM_PRETEND_VERSION="$VLLM_VERSION" \
@@ -339,9 +344,9 @@ COPY --from=numba-builder /tmp/control /dev/null
 
 # install gcc-11, python, openblas, numactl, lapack
 RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,from=numa-builder,source=/numactl/,target=/numactl/,rw \
-    --mount=type=bind,from=lapack-builder,source=/lapack/,target=/lapack/,rw \
-    --mount=type=bind,from=openblas-builder,source=/OpenBLAS-$OPENBLAS_VERSION/,target=/openblas/,rw \
+    --mount=type=cache,from=numa-builder,source=/numactl/,target=/numactl/,rw \
+    --mount=type=cache,from=lapack-builder,source=/lapack/,target=/lapack/,rw \
+    --mount=type=cache,from=openblas-builder,source=/OpenBLAS-$OPENBLAS_VERSION/,target=/openblas/,rw \
     rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
     microdnf install --nodocs -y \
     tar findutils openssl \
@@ -361,12 +366,13 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # consume previously built wheels
 RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,from=torch-builder,source=/torchwheels/,target=/torchwheels/,ro \
-    --mount=type=bind,from=arrow-builder,source=/arrowwheels/,target=/arrowwheels/,ro \
-    --mount=type=bind,from=cv-builder,source=/opencvwheels/,target=/opencvwheels/,ro \
-    --mount=type=bind,from=vllmcache-builder,source=/hf_wheels/,target=/hf_wheels/,ro \
-    --mount=type=bind,from=vllmcache-builder,source=/vllmwheel/,target=/vllmwheel/,ro \
-    --mount=type=bind,from=numba-builder,source=/numbawheels/,target=/numbawheels/,ro \
+    --mount=type=cache,from=torch-builder,source=/torchwheels/,target=/torchwheels/,ro \
+    --mount=type=cache,from=arrow-builder,source=/arrowwheels/,target=/arrowwheels/,ro \
+    --mount=type=cache,from=cv-builder,source=/opencvwheels/,target=/opencvwheels/,ro \
+    --mount=type=cache,from=vllmcache-builder,source=/hf_wheels/,target=/hf_wheels/,ro \
+    --mount=type=cache,from=vllmcache-builder,source=/vllmwheel/,target=/vllmwheel/,ro \
+    --mount=type=cache,from=numba-builder,source=/numbawheels/,target=/numbawheels/,ro \
+    export PKG_CONFIG_PATH=$(find / -type d -name "pkgconfig" 2>/dev/null | tr '\n' ':') && uv pip install sentencepiece==0.2.0 && \
     HOME=/root uv pip install /opencvwheels/*.whl /arrowwheels/*.whl /torchwheels/*.whl /hf_wheels/*.whl /numbawheels/*.whl /vllmwheel/*.whl
 
 WORKDIR /home/vllm
@@ -401,7 +407,7 @@ USER root
 
 ARG VLLM_TGIS_ADAPTER_VERSION
 RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,from=vllmcache-builder,source=/vllmwheel/,target=/vllmwheel/,ro \
+    --mount=type=cache,from=vllmcache-builder,source=/vllmwheel/,target=/vllmwheel/,ro \
     HOME=/root uv pip install "$(echo /vllmwheel/*.whl)[tensorizer]" vllm-tgis-adapter==${VLLM_TGIS_ADAPTER_VERSION}
 
 ENV GRPC_PORT=8033 \


### PR DESCRIPTION
Backported fixes from rhoai-2.24 to main.
This includes fixes for 
1. RHOAIENG 31377
2. RHOAIENG 31376
3. Some konflux build failures
4. Updated base image to Ubi 9.6 and openblas 0.3.30.