### PR TITLE
chore: fix s390x build

### DIFF
--- a/build_vllm_s390x.sh
+++ b/build_vllm_s390x.sh
@@ -153,7 +153,7 @@ python setup.py bdist_wheel --dist-dir "${WHEEL_DIR}"
 # -------------------------
 cd ${CURDIR}
 
-export AWS_LC_VERSION=v0.31.0
+export AWS_LC_VERSION=v0.32.0
 git clone --recursive https://github.com/aws/aws-lc-rs.git
 cd aws-lc-rs
 git checkout tags/aws-lc-sys/${AWS_LC_VERSION}


### PR DESCRIPTION
Fixes s390x vllm build
changes need to be made in AWS lc needs to be made in source to allow outlines core to be built. One of the dependancies updated the version of aws-lc from v0.31.0 to v0.32.0