### PR TITLE
add on pull request tekton pipeline for rhoai-2.25

### DIFF
--- a/.tekton/odh-vllm-cpu-v2-25-pull-request.yaml
+++ b/.tekton/odh-vllm-cpu-v2-25-pull-request.yaml
@@ -1,0 +1,89 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/vllm-cpu?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-target-branch: "[rhoai-2.25]"
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-odh-vllm-cpu-v2-25
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-vllm-cpu-v2-25-on-pull-request
+  namespace: rhoai-tenant
+spec:
+  timeouts:
+    pipeline: 8h
+    tasks: 6h
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/rhoai/pull-request-pipelines:odh-vllm-cpu-{{revision}}
+  - name: additional-tags
+    value:
+    - 'pr-{{pull_request_number}}-into-{{target_branch}}'
+  - name: additional-labels
+    value:
+    - version=on-pr-{{revision}}
+    - io.openshift.tags=odh-vllm-cpu
+  - name: rhoai-version
+    value: "2.25.0"
+  - name: dockerfile
+    value: Dockerfile.konflux.cpu
+  - name: path-context
+    value: .
+  - name: hermetic
+    value: false
+  - name: build-source-image
+    value: true
+  - name: build-image-index
+    value: true
+  - name: build-platforms
+    value:
+    - linux/s390x
+    - linux/ppc64le
+  - name: image-expires-after
+    value: 5d
+  - name: enable-slack-failure-notification
+    value: "false"
+  taskRunSpecs:
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+        limits:
+          cpu: '16'
+          memory: 32Gi
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+        limits:
+          cpu: '16'
+          memory: 32Gi
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
## Summary                                                                                                                          
   - Adds `.tekton/odh-vllm-cpu-v2-25-pull-request.yaml` for manual Konflux builds on PRs targeting rhoai-2.25                         
   - Triggered only via `/build-konflux` comment (no automatic PR event triggering)                                                    
   - Builds for linux/s390x and linux/ppc64le using the multi-arch-container-build pipeline from konflux-central 