### PR TITLE
Pin PyArrow to 23.0.1 for ppc64le build

### DIFF
--- a/build_vllm_ppc64le.sh
+++ b/build_vllm_ppc64le.sh
@@ -130,8 +130,8 @@ install_torch_family() {
 install_pyarrow() {
     cd ${CURDIR}
     
-    # Pin to 19.0.1 — Arrow 20+ removed setup.py in favor of pyproject.toml/meson build
-    export PYARROW_VERSION=${PYARROW_VERSION:-"19.0.1"}
+    # Pin to 23.0.0 — Arrow 24+ removed setup.py in favor of pyproject.toml/meson build
+    export PYARROW_VERSION=${PYARROW_VERSION:-"23.0.0"}
 
     TEMP_BUILD_DIR=$(mktemp -d)
     cd ${TEMP_BUILD_DIR}

--- a/build_vllm_ppc64le.sh
+++ b/build_vllm_ppc64le.sh
@@ -130,11 +130,12 @@ install_torch_family() {
 install_pyarrow() {
     cd ${CURDIR}
     
-    export PYARROW_VERSION=${PYARROW_VERSION:-$(curl -s https://api.github.com/repos/apache/arrow/releases/latest | jq -r '.tag_name' | grep -Eo "[0-9\.]+")}
-    
+    # Pin to 19.0.1 — Arrow 20+ removed setup.py in favor of pyproject.toml/meson build
+    export PYARROW_VERSION=${PYARROW_VERSION:-"19.0.1"}
+
     TEMP_BUILD_DIR=$(mktemp -d)
     cd ${TEMP_BUILD_DIR}
-    
+
     : ================== Installing Pyarrow ==================
     git clone --recursive https://github.com/apache/arrow.git -b apache-arrow-${PYARROW_VERSION}
     cd arrow/cpp

--- a/build_vllm_ppc64le.sh
+++ b/build_vllm_ppc64le.sh
@@ -130,8 +130,8 @@ install_torch_family() {
 install_pyarrow() {
     cd ${CURDIR}
     
-    # Pin to 23.0.0 — Arrow 24+ removed setup.py in favor of pyproject.toml/meson build
-    export PYARROW_VERSION=${PYARROW_VERSION:-"23.0.0"}
+    # Pin to 23.0.1 — Arrow 24+ removed setup.py in favor of pyproject.toml/meson build
+    export PYARROW_VERSION=${PYARROW_VERSION:-"23.0.1"}
 
     TEMP_BUILD_DIR=$(mktemp -d)
     cd ${TEMP_BUILD_DIR}

--- a/build_vllm_s390x.sh
+++ b/build_vllm_s390x.sh
@@ -38,7 +38,9 @@ curl https://sh.rustup.rs -sSf | sh -s -- -y && \
 
 cd ${CURDIR}
 
-git clone https://github.com/apache/arrow.git
+# Pin to 23.0.1 — keep in sync with ppc64le; Arrow 24+ removed setup.py
+export PYARROW_VERSION=${PYARROW_VERSION:-"23.0.1"}
+git clone https://github.com/apache/arrow.git -b apache-arrow-${PYARROW_VERSION}
 cd arrow/cpp
 mkdir -p release
 cd release


### PR DESCRIPTION
## Summary
- Apache Arrow 24.0.0 (latest) removed `setup.py` from `arrow/python/` in favor of a `pyproject.toml`/meson build system
- The `install_pyarrow()` function in `build_vllm_ppc64le.sh` dynamically fetched the latest Arrow release, which now resolves to 24.0.0 and breaks the build
- The s390x build was cloning Arrow from `main` (unpinned), risking version divergence across platforms
- Pinned `PYARROW_VERSION` to `23.0.1` on **both ppc64le and s390x** to ensure consistent PyArrow versions across platforms

**Failed PipelineRun:** [odh-vllm-cpu-v2-25-on-push-5zf26](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v2-25/pipelineruns/odh-vllm-cpu-v2-25-on-push-5zf26)

**Error:**
```
python: can't open file '/tmp/tmp.PEa4W1aHqp/arrow/python/setup.py': [Errno 2] No such file or directory
```

## Test plan
- [ ] Retrigger the Konflux push pipeline on `rhoai-2.25` and verify both ppc64le and s390x builds succeed
- [ ] Verify the built images contain matching PyArrow versions