### PR TITLE
fix: update vLLM version from 0.18.0 to 0.19.1 for RHOAI 3.5-EA1

### DIFF
--- a/Dockerfile.konflux.cpu
+++ b/Dockerfile.konflux.cpu
@@ -7,7 +7,7 @@ ARG BASE_UBI_IMAGE_TAG=9.6-1754584681
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:${BASE_UBI_IMAGE_TAG} AS builder-base
 
-ARG VLLM_VERSION="0.18.0"
+ARG VLLM_VERSION="0.19.1"
 ARG PYTHON_VERSION=3.12
 ARG VLLM_TARGET_DEVICE=cpu
 
@@ -85,7 +85,7 @@ ENV PKG_CONFIG_PATH=${PCP_DIR}/usr/lib64/pkgconfig:/usr/local/lib/pkgconfig/
 ENV C_INCLUDE_PATH="/usr/local/include:$C_INCLUDE_PATH"
 ENV LD_LIBRARY_PATH=${PCP_DIR}/usr/lib64:${PCP_DIR}/usr/lib:${VIRTUAL_ENV}/lib64/python${PYTHON_VERSION}/site-packages/torch/lib:/usr/local/lib:$LD_LIBRARY_PATH:/usr/local/lib64:/usr/lib64:/usr/lib
 ENV UV_LINK_MODE=copy
-ARG VLLM_VERSION="0.18.0"
+ARG VLLM_VERSION="0.19.1"
 ENV UV_EXTRA_INDEX_URL=https://wheels.developerfirst.ibm.com/ppc64le/linux/+simple/
 ENV UV_INDEX_STRATEGY=unsafe-best-match
 


### PR DESCRIPTION
## Summary
Updated vLLM version from 0.18.0 to 0.19.1 in Dockerfile.konflux.cpu 
for RHOAI 3.5-EA1.

## Changes
- Updated VLLM_VERSION from 0.18.0 to 0.19.1 

## File Changed
- Dockerfile.konflux.cpu

## Jira
https://redhat.atlassian.net/browse/RHOAIENG-63241