### PR TITLE
fix: Konflux s390x build - skip gcc-toolset-14 on s390x

### DIFF
--- a/Dockerfile.konflux.cpu
+++ b/Dockerfile.konflux.cpu
@@ -49,13 +49,13 @@ COPY . .
 # build & install vLLM so that all transitive dependencies are build/downloaded into the uv cache
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install 'setuptools==77.0.3' && \
-    source /opt/rh/gcc-toolset-14/enable && \
+    if [ "$(uname -m)" = "ppc64le" ]; then source /opt/rh/gcc-toolset-14/enable; fi && \
     SETUPTOOLS_SCM_PRETEND_VERSION="$VLLM_VERSION" uv build \
       --wheel --out-dir ${WHEEL_DIR} --no-build-isolation && \
     uv pip install "$(echo ${WHEEL_DIR}/vllm*.whl)[tensorizer]" --refresh
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    source /opt/rh/gcc-toolset-14/enable && \
+    if [ "$(uname -m)" = "ppc64le" ]; then source /opt/rh/gcc-toolset-14/enable; fi && \
     export IBM_DEVPI_URL="https://wheels.developerfirst.ibm.com/ppc64le/linux/+simple/" && \
     uv cache prune && \
     uv pip install $WHEEL_DIR/*.whl --extra-index-url $IBM_DEVPI_URL --index-strategy unsafe-best-match --verbose --force-reinstall --refresh


### PR DESCRIPTION
## Summary

- Fix s390x Konflux failure: \`/opt/rh/gcc-toolset-14/enable\` not found
- Source gcc-toolset-14 only on ppc64le; s390x uses system GCC from \`build_vllm_s390x.sh\`

## Jira
- https://redhat.atlassian.net/browse/RHOAIENG-64164

