### PR TITLE
Fix: Konflux s390x build - skip gcc-toolset-14

### DIFF
--- a/Dockerfile.konflux.cpu
+++ b/Dockerfile.konflux.cpu
@@ -49,13 +49,13 @@ COPY . .
 # build & install vLLM so that all transitive dependencies are build/downloaded into the uv cache
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install 'setuptools==77.0.3' && \
-    source /opt/rh/gcc-toolset-14/enable && \
+    if [ "$(uname -m)" = "ppc64le" ]; then source /opt/rh/gcc-toolset-14/enable; fi && \
     SETUPTOOLS_SCM_PRETEND_VERSION="$VLLM_VERSION" uv build \
       --wheel --out-dir ${WHEEL_DIR} --no-build-isolation && \
     uv pip install "$(echo ${WHEEL_DIR}/vllm*.whl)[tensorizer]" --refresh
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    source /opt/rh/gcc-toolset-14/enable && \
+    if [ "$(uname -m)" = "ppc64le" ]; then source /opt/rh/gcc-toolset-14/enable; fi && \
     export IBM_DEVPI_URL="https://wheels.developerfirst.ibm.com/ppc64le/linux/+simple/" && \
     uv cache prune && \
     uv pip install $WHEEL_DIR/*.whl --extra-index-url $IBM_DEVPI_URL --index-strategy unsafe-best-match --verbose --force-reinstall --refresh


### PR DESCRIPTION
## Summary
Fix Konflux s390x build failure in \`Dockerfile.konflux.cpu\`: gcc-toolset-14 is not installed on s390x as it uses system build. Source gcc-toolset-14 only on ppc64le.

## Jira
https://redhat.atlassian.net/browse/RHOAIENG-64164