### PR TITLE
Fix s390x std::pair initialization failure in cpu_attn_vec

### DIFF
--- a/csrc/cpu/cpu_attn_vec.hpp
+++ b/csrc/cpu/cpu_attn_vec.hpp
@@ -20,11 +20,11 @@ FORCE_INLINE std::pair<vec_op::FP32Vec16, vec_op::FP32Vec16> load_b_pair_vec(
     // 127).
     vec_op::BF16Vec32 bf16_b_reg(reinterpret_cast<const uint8_t*>(ptr),
                                  vec_op::fp8_e4m3_tag{});
-    return {vec_op::FP32Vec16(bf16_b_reg, 0), vec_op::FP32Vec16(bf16_b_reg, 1)};
+    return std::make_pair(vec_op::FP32Vec16(bf16_b_reg, 0), vec_op::FP32Vec16(bf16_b_reg, 1));
   } else if constexpr (std::is_same_v<kv_cache_t, c10::Float8_e5m2>) {
     vec_op::BF16Vec32 bf16_b_reg(reinterpret_cast<const uint8_t*>(ptr),
                                  vec_op::fp8_e5m2_tag{});
-    return {vec_op::FP32Vec16(bf16_b_reg, 0), vec_op::FP32Vec16(bf16_b_reg, 1)};
+    return std::make_pair(vec_op::FP32Vec16(bf16_b_reg, 0), vec_op::FP32Vec16(bf16_b_reg, 1));
   } else {
     using load_vec_t = typename VecTypeTrait<kv_cache_t>::vec_t;
     return std::make_pair(vec_op::FP32Vec16(load_vec_t(ptr)),


### PR DESCRIPTION
## Problem

The vLLM 0.21 rebase fails on s390x while compiling the CPU attention extension.

Build error:

```text
/root/csrc/cpu/cpu_attn_vec.hpp:23:79: error: could not convert
'{vec_op::FP32Vec16(bf16_b_reg, 0), vec_op::FP32Vec16(bf16_b_reg, 1)}'
from '<brace-enclosed initializer list>'
to 'std::pair<vec_op::FP32Vec16, vec_op::FP32Vec16>'

/root/csrc/cpu/cpu_attn_vec.hpp:27:79: error: could not convert
'{vec_op::FP32Vec16(bf16_b_reg, 0), vec_op::FP32Vec16(bf16_b_reg, 1)}'
from '<brace-enclosed initializer list>'
to 'std::pair<vec_op::FP32Vec16, vec_op::FP32Vec16>'
```

## Root Cause

The newly introduced FP8 KV-cache code path in `csrc/cpu/cpu_attn_vec.hpp` returns:

```cpp
return {vec_op::FP32Vec16(bf16_b_reg, 0),
        vec_op::FP32Vec16(bf16_b_reg, 1)};
```

while the function return type is:

```cpp
std::pair<vec_op::FP32Vec16, vec_op::FP32Vec16>
```

GCC on s390x rejects this conversion from a brace-enclosed initializer list to `std::pair`.

## Fix

Replace the brace initialization with:

```cpp
return std::make_pair(
    vec_op::FP32Vec16(bf16_b_reg, 0),
    vec_op::FP32Vec16(bf16_b_reg, 1));
```

for both FP8 code paths.

This matches the implementation already used by the non-FP8 path in the same function.

