### PR TITLE
Fix s390x Konflux build: torch 2.11 and restore llguidance

### DIFF
--- a/build_vllm_s390x.sh
+++ b/build_vllm_s390x.sh
@@ -86,7 +86,7 @@ make install
 export C_INCLUDE_PATH="/usr/local/include:$C_INCLUDE_PATH"
 
 # Download torch and setuptools (with correct version constraints for vllm)
-pip download torch==2.10.0+cpu \
+pip download torch==2.11.0+cpu \
   --index-url https://download.pytorch.org/whl/cpu \
   --extra-index-url https://pypi.org/simple \
   -d ${WHEEL_DIR}
@@ -99,10 +99,10 @@ pip download "setuptools==77.0.3" \
 # -------------------------
 # TorchVision
 # -------------------------
-export TORCH_VISION_VERSION=v0.20.1
+export TORCH_VISION_VERSION=v0.26.0
 cd ${CURDIR}
 uv pip install cmake ninja wheel "setuptools>=77.0.3,<81.0.0"
-uv pip install torch==2.10.0+cpu --index-url https://download.pytorch.org/whl/cpu
+uv pip install torch==2.11.0+cpu --index-url https://download.pytorch.org/whl/cpu
 git clone https://github.com/pytorch/vision.git
 cd vision
 git checkout $TORCH_VISION_VERSION

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -19,7 +19,7 @@ pillow  # Required for image processing
 prometheus-fastapi-instrumentator >= 7.0.0
 tiktoken >= 0.12.0  # Required for DBRX tokenizer, 0.12.0 is required to avoid requiring blobfile for local files, see https://github.com/openai/tiktoken/pull/446
 lm-format-enforcer == 0.11.3
-llguidance >= 1.3.0, < 1.4.0; platform_machine == "x86_64" or platform_machine == "arm64" or platform_machine == "aarch64" or platform_machine == "ppc64le"
+llguidance >= 1.3.0, < 1.4.0; platform_machine == "x86_64" or platform_machine == "arm64" or platform_machine == "aarch64" or platform_machine == "s390x" or platform_machine == "ppc64le"
 outlines_core == 0.2.14
 # required for outlines backend disk cache
 diskcache == 5.6.3


### PR DESCRIPTION
- Bump torch to 2.11.0+cpu and torchvision to v0.26.0 in build_vllm_s390x.sh so vllm 0.21.0 wheel install resolves torch deps on s390x.
- Add s390x back to llguidance platform marker in common.txt (rebase dropped it vs upstream); Validated locally on s390x with podman build of Dockerfile.konflux.cpu.