### PR TITLE
Optimize vLLM runtime

### DIFF
--- a/Dockerfile.konflux.cpu
+++ b/Dockerfile.konflux.cpu
@@ -54,11 +54,6 @@ RUN --mount=type=cache,target=/root/.cache/uv \
       --wheel --out-dir ${WHEEL_DIR} --no-build-isolation && \
     uv pip install "$(echo ${WHEEL_DIR}/vllm*.whl)[tensorizer]" --refresh
 
-RUN --mount=type=cache,target=/root/.cache/uv \
-    if [ "$(uname -m)" = "ppc64le" ]; then source /opt/rh/gcc-toolset-14/enable; fi && \
-    export IBM_DEVPI_URL="https://wheels.developerfirst.ibm.com/ppc64le/linux/+simple/" && \
-    uv pip install $WHEEL_DIR/*.whl --extra-index-url $IBM_DEVPI_URL --index-strategy unsafe-best-match --verbose --force-reinstall --refresh
-
 ###############################################################
 #                   FINAL VLLM IMAGE STAGE                    #
 ###############################################################
@@ -136,15 +131,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN microdnf install --nodocs -y util-linux && \
     microdnf clean all
 
-
-# consume previously built wheels
-RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=cache,from=builder-base,source=/wheelsdir/,target=/wheelsdir/,ro \
-    export PKG_CONFIG_PATH=$(find / -type d -name "pkgconfig" 2>/dev/null | tr '\n' ':') && \
-    # --offline will ensure wheels are picked from uv cache and nothing is pulled from pypi/built from source
-    # vllm wheel should be present in /wheelsdir/ ( at least for ppc64le - and transitive dependencies in uv cache )
-    uv pip install 'setuptools==77.0.3' && \
-    HOME=/root uv pip install /wheelsdir/*.whl --offline
+# Use builder venv in final stage instead of wheel reinstallation
+COPY --from=builder-base /opt/vllm /opt/vllm
 
 ENV LD_PRELOAD=/usr/lib64/libtcmalloc.so.4
 

--- a/build_vllm_ppc64le.sh
+++ b/build_vllm_ppc64le.sh
@@ -188,7 +188,7 @@ uv pip install ${WHEEL_DIR}/*.whl \
 ########################################
 
 sed -i.bak -e 's/.*torch.*//g' pyproject.toml requirements/*.txt
-
+sed -i '/fastapi\[standard\]/ s/>= 0\.120\.1/>= 0.120.1, < 0.137/' requirements/common.txt
 # revert back for numba/llvmlite compatibility
 uv pip install "setuptools<70" --no-build-isolation
 
@@ -197,5 +197,3 @@ export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:/usr/
 uv pip install -r requirements/common.txt \
                -r requirements/cpu.txt \
                -r requirements/build/cpu.txt --extra-index-url "$IBM_DEVPI_URL" --index-strategy unsafe-best-match
-
-uv pip install "fastapi[standard]>=0.115.0,<0.137"

--- a/build_vllm_ppc64le.sh
+++ b/build_vllm_ppc64le.sh
@@ -197,3 +197,5 @@ export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:/usr/
 uv pip install -r requirements/common.txt \
                -r requirements/cpu.txt \
                -r requirements/build/cpu.txt --extra-index-url "$IBM_DEVPI_URL" --index-strategy unsafe-best-match
+
+uv pip install "fastapi[standard]>=0.115.0,<0.137"

--- a/build_vllm_ppc64le.sh
+++ b/build_vllm_ppc64le.sh
@@ -13,7 +13,7 @@ cd "$REPO_ROOT"
 ########################################
 
 IBM_DEVPI_URL=${IBM_DEVPI_URL:-"https://wheels.developerfirst.ibm.com/ppc64le/linux/+simple/"}
-RHOAI_INDEX_URL=${RHOAI_INDEX_URL:-"https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9-test/simple/"}
+RHOAI_INDEX_URL=${RHOAI_INDEX_URL:-"https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9/simple/"}
 
 ########################################
 # wheel dir


### PR DESCRIPTION
Fixes https://redhat.atlassian.net/browse/RHOAIENG-70231

Additionally the latest fastapi version which released yesterday caused an internal server when openai server is started. So, as per this https://github.com/vllm-project/vllm/issues/45596#issuecomment-4702686739, pinned fastapi version too in the same PR.