### PR TITLE
Add gcc-toolset-14 for s390x Konflux build(RHOAIENG-70232)

### DIFF
--- a/Dockerfile.konflux.cpu
+++ b/Dockerfile.konflux.cpu
@@ -49,7 +49,7 @@ COPY . .
 # build & install vLLM so that all transitive dependencies are build/downloaded into the uv cache
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install 'setuptools==77.0.3' && \
-    if [ "$(uname -m)" = "ppc64le" ]; then source /opt/rh/gcc-toolset-14/enable; fi && \
+    if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "s390x" ]; then source /opt/rh/gcc-toolset-14/enable; fi && \
     SETUPTOOLS_SCM_PRETEND_VERSION="$VLLM_VERSION" uv build \
       --wheel --out-dir ${WHEEL_DIR} --no-build-isolation && \
     uv pip install "$(echo ${WHEEL_DIR}/vllm*.whl)[tensorizer]" --refresh
@@ -85,7 +85,8 @@ ENV UV_INDEX_STRATEGY=unsafe-best-match
 
 RUN if [ "$(uname -m)" = "s390x" ]; then \
     microdnf install --nodocs -y \
-    gcc gcc-gfortran g++ make patch zlib-devel \
+    gcc-toolset-14 gcc-toolset-14-binutils gcc-toolset-14-libatomic-devel \
+    make patch zlib-devel \
     libjpeg-turbo-devel libtiff-devel libpng-devel libwebp-devel freetype-devel harfbuzz-devel \
     openssl-devel openblas openblas-devel autoconf automake libtool cmake numpy libsndfile \
     clang llvm-devel llvm clang-devel git perl-core \

--- a/build_vllm_s390x.sh
+++ b/build_vllm_s390x.sh
@@ -15,11 +15,20 @@ export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-/usr/lib64:/usr/lib}
 
 # install development packages
 microdnf install -y \
-    which procps findutils tar vim git gcc gcc-gfortran g++ gcc-c++ make patch zlib-devel \
+    which procps findutils tar vim git \
+    gcc-toolset-14 gcc-toolset-14-binutils gcc-toolset-14-libatomic-devel \
+    make patch zlib-devel \
     libjpeg-turbo-devel libtiff-devel libpng-devel libwebp-devel freetype-devel harfbuzz-devel \
     openssl-devel openblas openblas-devel autoconf automake libtool libzstd-devel cmake numpy libsndfile \
     clang clang-devel ninja-build perl-core llvm llvm-devel && \
     microdnf clean all
+
+source /opt/rh/gcc-toolset-14/enable
+export PATH=/opt/rh/gcc-toolset-14/root/usr/bin:$PATH
+export LD_LIBRARY_PATH=/opt/rh/gcc-toolset-14/root/usr/lib64:${LD_LIBRARY_PATH}
+export LIBRARY_PATH=/opt/rh/gcc-toolset-14/root/usr/lib64
+export PKG_CONFIG_PATH=/opt/rh/gcc-toolset-14/root/usr/lib64/pkgconfig:${PKG_CONFIG_PATH:-}
+
 
 pip install --no-cache -U pip setuptools wheel && \
 pip install --no-cache -U uv


### PR DESCRIPTION
## Summary
- Use `gcc-toolset-14` in `build_vllm_s390x.sh` for s390x builder dependencies.
- Replace gcc with `gcc-toolset-14` in the s390x runtime stage in `Dockerfile.konflux.cpu`
- Enable gcc-toolset-14 during vLLM wheel build on s390x (required for torch 2.11.0+cpu).

## Jira
[RHOAIENG-70232](https://redhat.atlassian.net/browse/RHOAIENG-70232)

## Background
Torch 2.11.0+cpu requires GCC 14 on s390x. The Konflux image previously had gcc 11.5.0, causing build/runtime issues.
