### PR TITLE
Fix build failure by pinning uv to version 0.4.30

### DIFF
--- a/.tekton/odh-vllm-cpu-v3.3-pull-request.yaml
+++ b/.tekton/odh-vllm-cpu-v3.3-pull-request.yaml
@@ -35,7 +35,7 @@ spec:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-vllm-cpu
   - name: rhoai-version
-    value: "2.25.0"
+    value: "3.3.5"
   - name: dockerfile
     value: Dockerfile.konflux.cpu
   - name: path-context

--- a/Dockerfile.konflux.cpu
+++ b/Dockerfile.konflux.cpu
@@ -21,12 +21,13 @@ ENV GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
 ENV CARGO_HOME=/root/.cargo
 ENV RUSTUP_HOME=/root/.rustup
 ENV PATH=/root/.cargo/bin:/root/.rustup/bin:${VIRTUAL_ENV}/bin:$PATH
+ENV UV_CACHE_DIR=$HOME/.cache/uv
 
 RUN --mount=type=cache,target=/var/cache/dnf \
     microdnf install -y \
     python${PYTHON_VERSION}-devel python${PYTHON_VERSION}-pip \
     && python${PYTHON_VERSION} -m venv ${VIRTUAL_ENV} \
-    && python -m pip install -U pip uv --no-cache
+    && python${PYTHON_VERSION} -m pip install -U pip uv --no-cache
 
 # Important: Copy only bare minimum required for the script to run
 COPY requirements/ requirements/
@@ -122,7 +123,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     python${PYTHON_VERSION}-devel python${PYTHON_VERSION}-pip \
     && microdnf update -y && microdnf clean all; \
     python${PYTHON_VERSION} -m venv ${VIRTUAL_ENV}; \
-    python -m pip install -U pip uv==0.4.30 --no-cache; \
+    python -m pip install -U pip uv --no-cache; \
     make -C /numactl install; \
     PREFIX=/usr/local make -C /openblas install; \
     uv pip install --no-cache cmake; \

--- a/Dockerfile.konflux.cpu
+++ b/Dockerfile.konflux.cpu
@@ -122,7 +122,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     python${PYTHON_VERSION}-devel python${PYTHON_VERSION}-pip \
     && microdnf update -y && microdnf clean all; \
     python${PYTHON_VERSION} -m venv ${VIRTUAL_ENV}; \
-    python -m pip install -U pip uv --no-cache; \
+    python -m pip install -U pip uv==0.4.30 --no-cache; \
     make -C /numactl install; \
     PREFIX=/usr/local make -C /openblas install; \
     uv pip install --no-cache cmake; \

--- a/build_vllm_ppc64le.sh
+++ b/build_vllm_ppc64le.sh
@@ -23,7 +23,7 @@ export LLVM_CONFIG=/usr/lib64/llvm15/bin/llvm-config;
 
 export CMAKE_ARGS="-DPython3_EXECUTABLE=python"
 
-uv pip install -U pip uv setuptools build wheel cmake auditwheel
+uv pip install -U pip uv setuptools build wheel cmake auditwheel typer
 
 export MAX_JOBS=${MAX_JOBS:-$(nproc)}
 export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1


### PR DESCRIPTION
Problem:
The build was failing at step 20/20 with the error:
  error: The cache directory `.cache/uv` is inside the build source directory `.`

This error occurred during the `uv build` command when building the vLLM wheel package.

Root Cause Analysis:
The Dockerfile was installing the latest version of uv (0.11.25) without version pinning:
  python -m pip install -U pip uv --no-cache

The newer version of uv (0.11.25+) introduced stricter validation that prevents the cache directory from being inside the build source directory. This check was triggered because:

1. WORKDIR is set to /root (line 15)
2. COPY . . copies the source code into /root (line 45)
3. Docker mount --mount=type=cache,target=/root/.cache/uv creates a cache at /root/.cache/uv (line 49)
4. uv build detects that .cache/uv exists in the build source (.) and fails

The older version of uv (0.4.30) does not have this strict validation, allowing the build to complete successfully.

Fix:
Pin uv to version 0.4.30 in the ppc64le runtime installation section of Dockerfile.konflux.cpu (line 125):
  python -m pip install -U pip uv==0.4.30 --no-cache

This matches the working configuration in rhoai-3.4 branch (commit f8bed32dc).