### PR TITLE
Fix FIPS: remove statically linked patchelf from s390x runtime image

### DIFF
--- a/build_vllm_s390x.sh
+++ b/build_vllm_s390x.sh
@@ -88,6 +88,7 @@ cd xet-core/hf_xet/
 uv pip install maturin patchelf
 sed -i '/python-source/d' pyproject.toml
 python -m maturin build --release --out "${WHEEL_DIR}"
+uv pip uninstall -y maturin patchelf
 
 # -------------------------
 # Build LLVM 15 from source
@@ -196,6 +197,7 @@ git checkout tags/${OUTLINES_CORE_VERSION}
 sed -i 's/version = "0.0.0"/version = "'"${OUTLINES_CORE_VERSION}"'"/' Cargo.toml
 uv pip install maturin
 python -m maturin build --release --out "${WHEEL_DIR}"
+uv pip uninstall -y maturin patchelf
 
 # -------------------------
 # Build wheel for OpenCV-Headless


### PR DESCRIPTION
## Summary
Fixes FIPS check-payload failure on s390x for odh-vllm-cpu-rhel9.

## Problem
pip-installed patchelf (used by maturin during hf-xet and outlines-core builds)
ships a statically linked binary at /opt/vllm/bin/patchelf, which fails FIPS scan.

## Fix
Add `uv pip uninstall -y maturin patchelf` after both maturin build steps in build_vllm_s390x.sh.

## Related
- Pipeline: odh-vllm-cpu-v3-5-on-push-z59dk
