### PR TITLE
fix: add maturin for  to build

### DIFF
--- a/build_vllm_ppc64le.sh
+++ b/build_vllm_ppc64le.sh
@@ -178,6 +178,7 @@ install_torch_family() {
     git clone --recursive https://github.com/pytorch/pytorch.git -b v${TORCH_VERSION}
     cd pytorch
     sed -i '/lintrunner ;/s/$/ and platform_machine != "ppc64le"/' requirements.txt
+    uv pip install maturin
     uv pip install -r requirements.txt \
        --extra-index-url "$IBM_DEVPI_URL" \
        --index-strategy unsafe-best-match \


### PR DESCRIPTION
Fixes build dependencies for `hypothesis` - needed for pytorch to build [ppc64le]