### PR TITLE
Fix SC2078 shellcheck failure in ci-bake-rocm.sh

### DIFF
--- a/.buildkite/scripts/ci-bake-rocm.sh
+++ b/.buildkite/scripts/ci-bake-rocm.sh
@@ -1557,8 +1557,8 @@ confirm_remote_image_push() {
         fi
 
         if [[ -z "${remote_revision}" \
-              && ${IMAGE_EXISTED_BEFORE_BUILD} -eq 0 \
-              && image_tag_is_commit_scoped ]]; then
+              && ${IMAGE_EXISTED_BEFORE_BUILD} -eq 0 ]] \
+              && image_tag_is_commit_scoped; then
             echo "Remote image exists under a commit-scoped tag; accepting push despite missing revision label."
             return 0
         fi


### PR DESCRIPTION
## Problem

The `sast-shell-check` Konflux task fails the `odh-vllm-cpu-v3-5` push pipeline (build `odh-vllm-cpu-v3-5-on-push-xntmd`) with a single shellcheck finding:

> This expression is constant. Did you forget a `$` somewhere? (SC2078)

Location: `.buildkite/scripts/ci-bake-rocm.sh:1561`, in `confirm_remote_image_push()`.

## Root cause

`image_tag_is_commit_scoped` is a **function** (defined at line 383) that returns an exit status. It was placed **inside** a `[[ ... ]]` test:

```bash
if [[ -z "${remote_revision}" \
      && ${IMAGE_EXISTED_BEFORE_BUILD} -eq 0 \
      && image_tag_is_commit_scoped ]]; then
```

Inside `[[ ]]`, bash evaluates `image_tag_is_commit_scoped` as the constant, non-empty **string literal** `"image_tag_is_commit_scoped"` — always true. So besides failing the lint gate, this is a real logic bug: the commit-scoped-tag check never actually executed, and the "accept push despite missing revision label" branch fired on only the first two conditions.

## Fix

Close the `[[ ]]` after the string/arithmetic tests and chain the function call with `&&` at the command level (a function's exit status cannot be evaluated inside `[[ ]]`):
Fixes - [RHOAIENG-81201](https://redhat.atlassian.net/browse/RHOAIENG-81201)
```bash
if [[ -z "${remote_revision}" \
      && ${IMAGE_EXISTED_BEFORE_BUILD} -eq 0 ]] \
      && image_tag_is_commit_scoped; then
```

## Verification

- `shellcheck --external-sources .buildkite/scripts/ci-bake-rocm.sh` no longer reports the constant-expression (SC2078) finding.
- `bash -n .buildkite/scripts/ci-bake-rocm.sh` passes.
- No new findings introduced by the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)