### PR TITLE
Fix s390x build when duplicated setuptools whl appeared in the $WHEEL_DIR

### DIFF
--- a/build_vllm_s390x.sh
+++ b/build_vllm_s390x.sh
@@ -92,7 +92,8 @@ pip download torch==2.10.0+cpu \
   -d ${WHEEL_DIR}
 
 # Download setuptools==77.0.3 specifically for vllm
-pip download "setuptools==77.0.3" \
+VLLM_SETUPTOOLS_VERSION="77.0.3"
+pip download "setuptools==${VLLM_SETUPTOOLS_VERSION}" \
   --extra-index-url https://pypi.org/simple \
   -d ${WHEEL_DIR}
 
@@ -253,7 +254,9 @@ cd ${CURDIR}
 
 mkdir -p lapack
 mkdir -p OpenBLAS
-rm -f ${WHEEL_DIR}/setuptools-8[12]*.whl ${WHEEL_DIR}/setuptools-7[0-6]*.whl || true
+
+# Keep only one version of the setuptools package specifically for vllm
+find "${WHEEL_DIR}" -name 'setuptools-*.whl' ! -name "setuptools-${VLLM_SETUPTOOLS_VERSION}*" -delete
 
 uv pip install ${WHEEL_DIR}/*.whl
 


### PR DESCRIPTION
The script runs 'pip install -U pip setuptools wheel' which downloads the latest setuptools — now 83.0.0. Then pip download torch==2.10.0+cpu pulls torch and its dependency setuptools into the $WHEEL_DIR - this saves setuptools-83.0.0-py3-none-any.whl.

Afer that it explicitly downloads setuptools-77.0.3 into the same folder. The cleanup glob 'rm -f ${WHEEL_DIR}/setuptools-8[12]*.whl' used to remove versions 81.x and 82.x — but 83.0.0 doesn't match 8[12]*, so it survived. Later, 'uv pip install ${WHEEL_DIR}/*.whl' tried to install everything, and uv failed with "conflicting URLs"

It worked before because at that time, the latest setuptools was 82.0.1, which was caught by the cleanup glob setuptools-8[12]*.whl and deleted. Once setuptools hit 83.0.0, it escaped the filter.

This brings more robust solution than the glob - delete every setuptools whl except for the desired version.